### PR TITLE
Don't ignore default virtual devices

### DIFF
--- a/src/pulseaudio.cpp
+++ b/src/pulseaudio.cpp
@@ -297,7 +297,8 @@ Sink *SinkModel::findPreferredSink() const
         QMapIterator<quint32, Sink *> it(context()->sinks().data());
         while (it.hasNext()) {
             it.next();
-            if (it.value()->isVirtualDevice() || it.value()->state() != state) {
+            if ((it.value()->isVirtualDevice()&& !it.value()->isDefault())
+                    || it.value()->state() != state) {
                 continue;
             }
             if (!ret) {


### PR DESCRIPTION
Ignoring virtual PA devices for volume control results in ignoring the
"Simultaneous output" devices. This makes it impossible to control them
with the volume keys, which is not what the user expects. As a workaround,
prefer not to ignore virtual devices that are marked as default.